### PR TITLE
Added pan and zoom to the renderer

### DIFF
--- a/lib/Renderer.js
+++ b/lib/Renderer.js
@@ -340,13 +340,10 @@ function defaultZoomSetup(graph, svg) {
       .style('pointer-events', 'all');
 
     // Capture the zoom behaviour from the svg
-    var zoom = d3.behavior.zoom();
-    svg = svg
-      .call(zoom)
-      .append('g');
-
-    // On zoom apply the zoom method
-    zoom.on('zoom', this._zoom(graph, svg));
+    containerSvg = svg;
+    svg = svg.append('g')
+      .attr('class', 'zoom');
+    containerSvg.call(this._zoom(graph, svg));
   }
 
   return svg;
@@ -354,9 +351,9 @@ function defaultZoomSetup(graph, svg) {
 
 // By default allow pan and zoom
 function defaultZoom(graph, svg) {
-  return function() {
+  return d3.behavior.zoom().on('zoom', function() {
     svg.attr('transform', 'translate(' + d3.event.translate + ')scale(' + d3.event.scale + ')');
-  };
+  });
 }
 
 function defaultPostLayout() {


### PR DESCRIPTION
Uses d3.behavior.zoom() to apply a transform to the main svg element
