### PR TITLE
Correct the value of markerUnits

### DIFF
--- a/lib/Renderer.js
+++ b/lib/Renderer.js
@@ -379,7 +379,7 @@ function defaultPostRender(graph, root) {
           .attr('viewBox', '0 0 10 10')
           .attr('refX', 8)
           .attr('refY', 5)
-          .attr('markerUnits', 'strokewidth')
+          .attr('markerUnits', 'strokeWidth')
           .attr('markerWidth', 8)
           .attr('markerHeight', 5)
           .attr('orient', 'auto')


### PR DESCRIPTION
'strokewidth' is in fact a harmless typo, but it's throwing scary warning/error messages in the browser. :)
