### PR TITLE
Node rectangles now use more style attributes from the node's meta-data

### DIFF
--- a/lib/Renderer.js
+++ b/lib/Renderer.js
@@ -212,7 +212,7 @@ function defaultDrawNodes(g, root) {
         .style('opacity', 0)
         .attr('class', 'node enter');
 
-  svgNodes.each(function(u) { addLabel(g.node(u), d3.select(this), 10, 10); });
+  svgNodes.each(function(u) { addLabel(g.node(u), d3.select(this), true, 10, 10); });
 
   this._transition(svgNodes.exit())
       .style('opacity', 0)
@@ -235,7 +235,7 @@ function defaultDrawEdgeLabels(g, root) {
         .style('opacity', 0)
         .attr('class', 'edgeLabel enter');
 
-  svgEdgeLabels.each(function(e) { addLabel(g.edge(e), d3.select(this), 0, 0); });
+  svgEdgeLabels.each(function(e) { addLabel(g.edge(e), d3.select(this), false, 0, 0); });
 
   this._transition(svgEdgeLabels.exit())
       .style('opacity', 0)
@@ -389,11 +389,18 @@ function defaultPostRender(graph, root) {
   }
 }
 
-function addLabel(node, root, marginX, marginY) {
+function addLabel(node, root, adding_node, marginX, marginY) {
   // Add the rect first so that it appears behind the label
   var label = node.label;
   var rect = root.append('rect');
-  var labelSvg = root.append('g');
+  if(node.width){
+      rect.attr('width', node.width);
+  }
+  if(node.height){
+      rect.attr('height', node.width);
+  }
+  
+  var labelSvg = root.append('g').style('stroke', '#00');
 
   if (label[0] === '<') {
     addForeignObjectLabel(label, labelSvg);
@@ -406,30 +413,45 @@ function addLabel(node, root, marginX, marginY) {
                  node.labelCut);
   }
 
-  var bbox = root.node().getBBox();
-
+  var label_bbox = labelSvg.node().getBBox();
   labelSvg.attr('transform',
-             'translate(' + (-bbox.width / 2) + ',' + (-bbox.height / 2) + ')');
+                'translate(' + (-label_bbox.width / 2) + ',' + (- label_bbox.height / 2) + ')');
 
+  var bbox = root.node().getBBox();
+  
   rect
-    .attr('rx', 5)
-    .attr('ry', 5)
+    .attr('rx', node.rx || 5)
+    .attr('ry', node.rx || 5)
     .attr('x', -(bbox.width / 2 + marginX))
     .attr('y', -(bbox.height / 2 + marginY))
     .attr('width', bbox.width + 2 * marginX)
     .attr('height', bbox.height + 2 * marginY)
-    .attr('fill', '#fff');
+    .style('fill', '#fff');
+  
+  if(adding_node){
 
-  if (node.fill) {
-    rect.attr('fill', node.fill);
-  }
+      if (node.fill) {
+        rect.style('fill', node.fill);
+      }
 
-  if (node.href) {
-    root
-      .attr('class', root.attr('class') + ' clickable')
-      .on('click', function() {
-        window.open(node.href);
-      });
+      if(node.stroke){
+         rect.style('stroke', node.stroke);
+      }
+
+      if(node['stroke-width']){
+          rect.style('stroke-width', node['stroke-Width'] + 'px');
+      }
+      if(node['stroke-dasharray']){
+          rect.style('stroke-dasharray', node['stroke-dasharray']);
+      }
+
+      if (node.href) {
+           root
+              .attr('class', root.attr('class') + ' clickable')
+              .on('click', function() {
+                   window.open(node.href);
+               });
+      }
   }
 }
 


### PR DESCRIPTION
This is a minor step in the direction of fully configurable node shapes.

In addition to the already supported fill and href attributes, the
following additional (style) attributes are now supported:
- width and height
- stroke, 
- stroke-width, 
- stroke—dasharray, 
- rx, ry

Changes:
- Added a Boolean argument “adding_node” to addLabel to differentiate 
  the cases of adding a node or an edge label. It can be argued that it 
  is better to split addLabel in two separate functions. I have not 
  done that to make the changes as small as possible.
- In the body of addLabel: added code to set the various style  
  attributes when they are defined in the node’s meta-data.
