### PR TITLE
Implemented "arbitrary" node shapes

### DIFF
--- a/demo/user-defined-nodes.html
+++ b/demo/user-defined-nodes.html
@@ -37,30 +37,46 @@ text {
 
 <body onLoad="draw();">
 
-<svg x="0" y="0" width=269 height=391>
-<g transform="translate(20,20)"/>
+<svg x="0" y="0" width=350 height=800>
+
+<g transform="translate(20,20)">
 
 <defs>
-	<g id="N0" width="30" height="30" transform="translate(-15,-15)"><polygon points="0,16.01017916333157 15.22658522033938,4.947417444457132 9.410547198766546,-12.952507026122916 -9.410547198766542,-12.952507026122918 -15.22658522033938,4.94741744445713 -3.921362932176701e-15,16.01017916333157 " transform="translate(15.726585388183594,13.452507019042969)" style="stroke: rgb(0, 0, 0); fill: rgb(255, 255, 0); stroke-width: 1px;"></polygon><text x="6.276585388183593" y="17.82555389404297" width="18.900000000000002" height="16.81640625" style="text-anchor: start; font-family: 'Helvetica Neue Light', Helvetica, Arial, sans-serif; font-style: normal; font-weight: 300; font-size: 14px; stroke: rgb(0, 0, 0); stroke-width: 1px; fill: rgb(0, 0, 0);">N0</text></g>
-	<g id="N1" width="119" height="113" transform="translate(-59.5,-56.5)"><g transform="scale(0.5,0.5)"><polygon points="350,75,379,161,469,161,397,215,423,301,350,250,277,301,303,215,231,161,321,161" transform="translate(-229,-73)" style="stroke: rgb(0, 0, 0); fill-rule: evenodd; fill: rgb(0, 0, 255); stroke-width: 4px;"></polygon></g></g>
-	<g id="N2" width="80" height="80" transform="translate(-40,-40)"><ellipse cx="40.5" cy="40.5" rx="40" ry="40" style="stroke: rgb(0, 0, 0); fill: rgb(173, 216, 230); stroke-width: 1px;"></ellipse><text x="31.049999999999997" y="44.873046875" width="18.900000000000002" height="16.81640625" style="text-anchor: start; font-family: 'Helvetica Neue Light', Helvetica, Arial, sans-serif; font-style: normal; font-weight: 300; font-size: 14px; stroke: rgb(0, 0, 0); stroke-width: 1px; fill: rgb(0, 0, 0);">N2</text></g>
+	<g id="def-N0" ><rect x=-25 y =-25 width=50 height=50 fill="steelblue"/><circle cx=0 cy=0 r=20 fill="yellow"/><text x=-7 y=5 fill="#000000">N0</text></g>
+	<g id="def-N1" transform="translate(-40,-20)"><polygon points="0,20 20,0 35,0 35,10, 20,10, 20,20 60,20 60,10 45,10 45,0 60,0 80,20 60,50 40,35 20,50" style="fill:lightgreen;stroke:black;stroke-width:2;"/><text x=35 y=33 fill="#FF">N1</text></g>
+	<g id="def-N2" ><ellipse cx=0 cy=0 rx=50 ry=30 fill="#FFC0C0"/><text x=-7 y=5 fill="#FFFFFF">N2</text></g>
+	<g id="def-N3" transform="translate(-40,-20)"><polygon points="0,20 20,0 35,0 35,10, 20,10, 20,20 60,20 60,10 45,10 45,0 60,0 80,20 60,50 40,35 20,50" style="fill:lightgray;stroke:black;stroke-width:2;"/><text x=35 y=33 fill="#FF">N3</text></g>
+	<g id="def-N4" ><circle cx=0 cy=0 r=30 fill="#F0B3FF"/><text x=-7 y=5 fill="#FFFFFF">N4</text></g>
+	<g id="def-N5" transform="translate(-98,-98)"><polygon points= "100,10 40,198 190,78 10,78 160,198" fill-rule="evenodd" style="fill:silver;"/>
+	
 </defs>
 
+</g>
 </svg>
 
 <script>
 function draw() {
   var g = new dagreD3.Digraph();
-  g.addNode("N0", {label: "N0", use: "N0"});
-  g.addNode("N1", {label: "N1", use: "N1"});
-  g.addNode("N2", {label: "N2", use: "N2"});
+  g.addNode("N0", {label: "N0", use: "def-N0"});
+  g.addNode("N1", {label: "N1", use: "def-N1"});
+  g.addNode("N2", {label: "N2", use: "def-N2"});
+  g.addNode("N3", {label: "N3", use: "def-N3"});
+  g.addNode("N4", {label: "N4", use: "def-N4"});
+  g.addNode("N5", {label: "N5", use: "def-N5"});
   
   g.addEdge(null, "N0",     "N1",     { label: "N0-N1" });
-  g.addEdge(null, "N1",     "N2",     { label: "N1-N2" });
-  g.addEdge(null, "N2",     "N0",     { label: "N2-N0" });
   g.addEdge(null, "N0",     "N2",     { label: "N0-N2" });
+  g.addEdge(null, "N1",     "N2",     { label: "N1-N2" });
+  g.addEdge(null, "N2",     "N3",     { label: "N2-N3" });
+  g.addEdge(null, "N3",     "N0",     { label: "N3-N0" });
+  g.addEdge(null, "N3",     "N4",     { label: "N3-N4" });
+  g.addEdge(null, "N4",     "N5",     { label: "N4-N5" });
+  g.addEdge(null, "N5",     "N0",     { label: "N5-N0" });
+ 
   
   var renderer = new dagreD3.Renderer();
+  var layout = dagreD3.layout()
+                    .rankSep(70);
   var oldDrawNodes = renderer.drawNodes();
   renderer.drawNodes(function(graph, root) {
     var svgNodes = oldDrawNodes(graph, root);
@@ -69,6 +85,6 @@ function draw() {
   });
  
   
-  renderer.run(g, d3.select("svg g"));
+  renderer.layout(layout).run(g, d3.select("svg g"));
 }
 </script>

--- a/lib/Renderer.js
+++ b/lib/Renderer.js
@@ -308,7 +308,7 @@ function isPolygon(obj) {
 
 function intersectNode(nd, p1, root){
   if (nd.label.match(/^[a-zA-Z0-9]+$/)) {
-      var definedFig = root.select('defs #' + nd.label).node();
+      var definedFig = root.select('defs #def-' + nd.label).node();
       if (definedFig) {
           var outerFig = definedFig.childNodes[0];
           if (isCircle(outerFig) || isEllipse(outerFig)) {
@@ -332,11 +332,13 @@ function defaultPositionEdgePaths(g, svgEdgePaths, root) {
     var target = g.node(g.incidentNodes(e)[1]);
     var points = value.points.slice();
 
-    //var p0 = points.length === 0 ? target : points[0];
+    var p0 = points.length === 0 ? target : points[0];
     var p1 = points.length === 0 ? source : points[points.length - 1];
     
-    points.unshift(source);	// ultimately we want here: points.unshift(intersectNode(source, p0, root));
-    
+    //points.unshift(source);	// ultimately we want this: 
+    console.log('intersect source -> p0');
+    points.unshift(intersectNode(source, p0, root));
+    console.log('intersect target -> p1');
     points.push(intersectNode(target, p1, root));
     
     return d3.svg.line()
@@ -594,7 +596,7 @@ function intersectEllipse(node, ellipseOrCircle, point) {
     var rx, ry;
     
     if(isCircle(ellipseOrCircle)){
-	rx = ry = ellipseOrCircle.rbaseVal.value;
+	rx = ry = ellipseOrCircle.r.baseVal.value;
     } else {
 	rx = ellipseOrCircle.rx.baseVal.value;
 	ry = ellipseOrCircle.ry.baseVal.value;
@@ -605,11 +607,11 @@ function intersectEllipse(node, ellipseOrCircle, point) {
     
     var det = Math.sqrt(rx * rx * py * py + ry * ry * px * px);
    
-    var dx = rx * ry * px / det;
+    var dx = Math.abs(rx * ry * px / det);
     if(point.x < cx){
 	dx = -dx;
     }
-    var dy = rx * ry * py / det;
+    var dy = Math.abs(rx * ry * py / det);
     if(point.y < cy){
 	dy = - dy;
     }
@@ -618,18 +620,26 @@ function intersectEllipse(node, ellipseOrCircle, point) {
 }
 
 function same_sign(r1, r2) {
-    return r1 * r2 >= 0;
+    return r1 * r2 > 0;
+}
+
+// Add point to the found interesctions, but check first that it is unique.
+
+function add_point(x, y, intersections){
+    if (!intersections.some(function (elm){ return elm[0] === x && elm[1] === y; })) {
+	intersections.push([x, y]);
+    }
 }
 
 function intersectLine(x1, y1, x2, y2, x3, y3, x4, y4, intersections){
-    // Adapted from http://processingjs.org/learning/custom/intersect/
+    // Algorithm from J. Avro, (ed.) Graphics Gems, No 2, Morgan Kaufmann, 1994, p7 and p473.
+    
     var a1, a2, b1, b2, c1, c2;
     var r1, r2 , r3, r4;
     var denom, offset, num;
     var x, y;
 
-    // Compute a1, b1, c1, where line joining points 1 and 2
-    // is "a1 x + b1 y + c1 = 0".
+    // Compute a1, b1, c1, where line joining points 1 and 2 is F(x,y) = a1 x + b1 y + c1 = 0.
     a1 = y2 - y1;
     b1 = x1 - x2;
     c1 = (x2 * y1) - (x1 * y2);
@@ -644,7 +654,7 @@ function intersectLine(x1, y1, x2, y2, x3, y3, x4, y4, intersections){
       return /*DONT_INTERSECT*/;
     }
 
-    // Compute a2, b2, c2
+    // Compute a2, b2, c2 where line joining points 3 and 4 is G(x,y) = a2 x + b2 y + c2 = 0 
     a2 = y4 - y3;
     b2 = x3 - x4;
     c2 = (x4 * y3) - (x3 * y4);
@@ -652,7 +662,7 @@ function intersectLine(x1, y1, x2, y2, x3, y3, x4, y4, intersections){
     // Compute r1 and r2
     r1 = (a2 * x1) + (b2 * y1) + c2;
     r2 = (a2 * x2) + (b2 * y2) + c2;
-
+    
     // Check signs of r1 and r2. If both point 1 and point 2 lie
     // on same side of second line segment, the line segments do
     // not intersect.
@@ -660,7 +670,7 @@ function intersectLine(x1, y1, x2, y2, x3, y3, x4, y4, intersections){
       return /*DONT_INTERSECT*/;
     }
 
-    //Line segments intersect: compute intersection point.
+    // Line segments intersect: compute intersection point.
     denom = (a1 * b2) - (a2 * b1);
     if (denom === 0) {
       return /*COLLINEAR*/;
@@ -678,9 +688,7 @@ function intersectLine(x1, y1, x2, y2, x3, y3, x4, y4, intersections){
     y = (num < 0) ? ((num - offset) / denom) : ((num + offset) / denom);
 
     // lines_intersect
-    if (!intersections.some(function (elm){ return elm[0] === x && elm[1] === y; })) {
-	intersections.push([x, y]);
-    }
+    add_point(x, y, intersections);
     return;
   }
 
@@ -689,27 +697,47 @@ function intersectPolygon(node, polygon, point) {
     var y1 = node.y;
     var x2 = point.x;
     var y2 = point.y;
-    var intersections = [];
     
+    var intersections = [];
     var points = polygon.points;
-    console.log('intersectPolygon', points);
+    
+    var minx = 100000, miny = 100000;
+    for(var j = 0; j < points.numberOfItems; j++){
+	var p = points.getItem(j);
+	minx = Math.min(minx, p.x);
+	miny = Math.min(miny, p.y);
+    }
+    
+    var left = x1 - node.width/2 - minx;
+    var top =  y1 - node.height/2 - miny;
     
     for(var i = 0; i < points.numberOfItems; i++){
 	var p1 = points.getItem(i);
 	var p2 = points.getItem(i < points.numberOfItems - 1 ? i + 1 : 0);
-	intersectLine(x1, y1, x2, y2, x1 + p1.x, y1 + p1.y, x1 + p2.x, y1 + p2.y, intersections);
+	intersectLine(x1, y1, x2, y2, left + p1.x, top + p1.y, left + p2.x, top + p2.y, intersections);
     }
-
+   
     if(intersections.length === 1){
-       return {x: intersections[0][0], y: intersections[0][1]};
+	return {x: intersections[0][0], y: intersections[0][1]};
      }
     if(intersections.length > 1){
-       console.log('Too many intersections found', intersections);
+       // More intersections, find the one nearest to edge end point
+       intersections.sort(function(p, q){
+           var pdx = p[0] - point.x,
+               pdy = p[1] - point.y,
+               distp = Math.sqrt(pdx * pdx + pdy * pdy),
+
+               qdx = q[0] - point.x,
+               qdy = q[1] - point.y,
+               distq = Math.sqrt(qdx * qdx + qdy * qdy);
+
+           return (distp < distq) ? -1 : (distp === distq ? 0 : 1);
+       });
        return {x: intersections[0][0], y: intersections[0][1]};
     } else {
-       console.log('No intersections found:', polygon, point);
+       console.log('NO INTERSCTION FOUND, RETURN NODE CENTER', node);
+       return node;
     }
-    return node;
 }
 
 function isComposite(g, u) {


### PR DESCRIPTION
Added optional "use" element in node meta-data for user-defined node shapes

The basic idea is that instead of the standard rectangle that is now drawn for each node, a separate shape can be defined per node.

This is achieved by adding an extra `use` field that holds the name of an SVG `def` element. Whenever a node is rendered and the use element is present, the defined element will be drawn. See `demos/user-defined-nodes.html` for an example.

The defined node shape element should satisfy the following requirements:
- It occurs in a `defs` section that is part of the svg in which the graph is being rendered.
- It is wrapped in a group element with the same `id` as occurs in the `use` element in the node's meta-data.
- The first element in the group is one of the following shapes for which special boundary intersection algorithms have been implemented:
  - circle
  - ellipse
  - polygon
- When these requirements are not satisfied, the node shape is treated as a rectangle.

A typical (good) example of a defined node shape is:

```
<g id="def-N4"><circle cx=0 cy=0 r=30 fill="#F0B3FF"/><text x=-7 y=5 fill="#FFFFFF">N4</text></g>
```

**Caveats**:
- The above rules forbid node shapes surrounded by extra transformations (e.g. scale, rotate).
- The connection points for concave polygons are not yet pixel perfect. I am still looking into this.
