### PR TITLE
fix #50: browserify -s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,18 @@ demo-test: test/demo-test.js $(SRC_FILES) node_modules
 bower.json: package.json src/release/make-bower.json.js
 	src/release/make-bower.json.js > $@
 
-$(BUILD_DIR)/$(MOD).js: browser.js $(SRC_FILES) $(BUILD_DIR) | lint
+$(BUILD_DIR)/$(MOD).js: index.js $(SRC_FILES) $(BUILD_DIR) | lint
 	$(BROWSERIFY) $(BROWSERIFY_OPTS) $< > $@ \
 		-x node_modules/d3/index.js \
-		-x node_modules/d3/d3.js
+		-x node_modules/d3/d3.js \
+		-s dagreD3
 
 $(BUILD_DIR)/$(MOD).min.js: $(BUILD_DIR)/$(MOD).js
 	@$(UGLIFY) $< --comments '@license' > $@
 
-$(BUILD_DIR)/$(MOD).core.js: browser.js $(SRC_FILES) $(BUILD_DIR) | lint
-	@$(BROWSERIFY) $< > $@ --no-bundle-external
+$(BUILD_DIR)/$(MOD).core.js: index.js $(SRC_FILES) $(BUILD_DIR) | lint
+	@$(BROWSERIFY) $< > $@ --no-bundle-external \
+		-s dagreD3
 
 $(BUILD_DIR)/$(MOD).core.min.js: $(BUILD_DIR)/$(MOD).core.js
 	@$(UGLIFY) $< --comments '@license' > $@


### PR DESCRIPTION
This apparently fixes #50 by using `browserify index.js -s dagreD3` instead of `browserify browser.js`. Looks like the tests pass!

Since the IPython notebook was mentioned, and is what I wanted it for, I've made a [notebook with an embedded build](http://nbviewer.ipython.org/gist/bollwyvl/6b1945104c8fdaedd82c/dagre-d3%20vs%20require.js%20in%20the%20IPython%20Notebook.ipynb).

I don't know how to add testing require.js behavior to the test suite... there is some [old doc](http://karma-runner.github.io/0.8/plus/RequireJS.html) about using r.js with karma, but I have never worked with it before. It could be that we can just trust browserify, which is usually smarter than me, but I would kind of like to know that this was being looked after.

There are some warnings on the browsersify doc related to how this might affect downstream builds that are explicitly looking for `require`... I also don't know how to test that until it breaks someone's stuff.

Hopefully this helps!
