### PR TITLE
Add edge.elem property

### DIFF
--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -32,7 +32,7 @@ function createEdgePaths(selection, g, arrows) {
       util.applyTransition(domEdge, g)
         .attr("d", function(e) { return calcPoints(g, e); });
 
-      if (edge.id) { domEdge.attr("id", edge.id); }
+      if (edge.id) { d3.select(edge.elem).attr("id", edge.id); }
       util.applyStyle(domEdge, edge.style);
     });
 

--- a/test/bundle-test.js
+++ b/test/bundle-test.js
@@ -68,7 +68,7 @@ describe("dagreD3", function() {
       expect(d3.select("#ab").datum()).eqls({ v: "a", w: "b" });
 
       // We should also be able to get to the element from the edge object.
-      expect(g.edge("a", "b").elem).to.equal(d3.select("#ab").node().parentNode);
+      expect(g.edge("a", "b").elem).to.equal(d3.select("#ab").node());
     });
 
     it("are created for each edge label", function() {
@@ -211,7 +211,7 @@ describe("dagreD3", function() {
       g.setEdge("a", "b", { id: "ab", style: "stroke: #ff0000" });
       dagreD3.render()(svg, g);
 
-      expect(d3.select("#ab").style("stroke")).to.equal(canonicalRed);
+      expect(d3.select("#ab path").style("stroke")).to.equal(canonicalRed);
     });
 
     it("can be applied to an edge label", function() {


### PR DESCRIPTION
This property is automatically added on nodes (https://github.com/cpettitt/dagre-d3/blob/master/lib/create-nodes.js#L29) and is quite useful if you want to manipulate the svg node. In case we want to manipulate the svg edge, this PR is quite cool :)

Let me know your opinion on it.
