### PR TITLE
Record edge-to-element mapping.

### DIFF
--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -18,6 +18,11 @@ function createEdgePaths(selection, g, arrows) {
   util.applyTransition(svgPaths, g)
     .style("opacity", 1);
 
+  svgPaths.each(function(e) {
+    var edge = g.edge(e);
+    edge.elem = this;
+  });
+
   svgPaths.selectAll("path.path")
     .each(function(e) {
       var edge = g.edge(e);


### PR DESCRIPTION
For nodes, the top-level 'g' element is already recorded as
node.elem field. This patch makes the same done for edges.

The motivating example is highlighting a neighbourhood of a
node on hover - given a node I can easily traverse neighbours,
but to add a class to edge I need to know SVG element.
