### PR TITLE
Add quotes around object attributes that are also keywords to some js pa...

### DIFF
--- a/lib/create-nodes.js
+++ b/lib/create-nodes.js
@@ -30,7 +30,8 @@ function createNodes(selection, g, shapes) {
 
     if (node.id) { thisGroup.attr("id", node.id); }
     if (node.labelId) { labelGroup.attr("id", node.labelId); }
-    util.applyClass(thisGroup, node.class, (thisGroup.classed("update") ? "update " : "") + "node");
+    util.applyClass(thisGroup, node["class"], (
+      thisGroup.classed("update") ? "update " : "") + "node");
 
     if (_.has(node, "width")) { bbox.width = node.width; }
     if (_.has(node, "height")) { bbox.height = node.height; }


### PR DESCRIPTION
Hi, 

I was using your projects (dagre/dagre-d3) for a website and we use yuicompressor to automatically compress all our javascript assets.  However, there is a problem where certain attributes in the codebase are also reserved keywords.  I realize it's yuicompressor's fault for not handling this correctly, but would you consider accepting this PR?  All it does is change the attribute access from dot notation to bracket notation for values that are also keywords. 

Thanks for your time and thanks for these libraries.
