### PR TITLE
Prevent IE11 XMLSerializer from adding namespace attributes to tspan

### DIFF
--- a/lib/label/add-text-label.js
+++ b/lib/label/add-text-label.js
@@ -12,7 +12,7 @@ function addTextLabel(root, node) {
   for (var i = 0; i < lines.length; i++) {
     domNode
       .append("tspan")
-        .attr("xml:space", "preserve")
+        .attr("space", "preserve")
         .attr("dy", "1em")
         .attr("x", "1")
         .text(lines[i]);


### PR DESCRIPTION
IE11 XMLSerializer gives wrong output when tspan's `xml:space` is given with the namespace (the DOM view looks fine, the problem happens when serializing it or using jQuery's `.html()` on the SVG's parent).

I honestly have no idea if this breaks compatibility with other browsers or if I'm doing something wrong but this seem to fix it. Did some manual testing on my Windows 7 machine and on Chrome everything seems to work. On Firefox too, with the only difference that the XMLSerializer adds back the "xml:" in front of the "space" attribute.

Expected output:

```
<svg xmlns="http://www.w3.org/2000/svg" id="graph">
    <g transform="translate(0)">
        <g class="output">
            <g class="clusters" />
            <g class="edgePaths" />
            <g class="edgeLabels" />
            <g class="nodes">
                <g class="node" style="opacity: 1;" transform="translate(164.06 45.77)">
                    <rect x="-144.06" y="-25.77" width="288.12" height="51.54" rx="10" ry="10" />
                    <g class="label" transform="translate(0)">
                        <g transform="translate(-137.06 -18.77)">
                            <text>
                                <tspan x="1" dy="1em" space="preserve">TITLE</tspan>
                                <tspan x="1" dy="1em" space="preserve">SUBTITLE</tspan>
                            </text>
                        </g>
                    </g>
                </g>
            </g>
        </g>
    </g>
</svg>
```

Actual output:

```
<svg xmlns="http://www.w3.org/2000/svg" id="graph">
    <g transform="translate(0)">
        <g class="output">
            <g class="clusters" />
            <g class="edgePaths" />
            <g class="edgeLabels" />
            <g class="nodes">
                <g class="node" style="opacity: 1;" transform="translate(164.06 45.77)">
                    <rect x="-144.06" y="-25.77" width="288.12" height="51.54" rx="10" ry="10" />
                    <g class="label" transform="translate(0)">
                        <g transform="translate(-137.06 -18.77)">
                            <text>
                                <tspan x="1" dy="1em"
                                    xmlns:NS1="http://www.w3.org/XML/1998/namespace" NS1:space="preserve">TITLE
                                </tspan>
                                <tspan x="1" dy="1em"
                                    xmlns:NS2="http://www.w3.org/XML/1998/namespace" NS2:space="preserve">SUBTITLE
                                </tspan>
                            </text>
                        </g>
                    </g>
                </g>
            </g>
        </g>
    </g>
</svg>
```
