### PR TITLE
Throw error if node not found in preProcessGraph function

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -93,6 +93,9 @@ var EDGE_DEFAULT_ATTRS = {
 function preProcessGraph(g) {
   g.nodes().forEach(function(v) {
     var node = g.node(v);
+    if (node === undefined){
+      throw new Error("Could not find node " + v);
+    }
     if (!_.has(node, "label") && !g.children(v).length) { node.label = v; }
 
     if (_.has(node, "paddingX")) {


### PR DESCRIPTION
I was bitten by this, and it took me some time to narrow it down to this.
Essentially, when I tried to add an edge to a node which doesn't exist, the minified js threw a cryptic `t is undefined` error. This should hopefully take care of the sanity of the next developer.
