### PR TITLE
Allow d3 to load from require or window

### DIFF
--- a/lib/d3.js
+++ b/lib/d3.js
@@ -1,2 +1,15 @@
-// Stub to get D3 either via NPM or from the global object
-module.exports = window.d3;
+/* global window */
+
+var d3;
+
+if (require) {
+  try {
+    d3 = require("d3");
+  } catch (e) {}
+}
+
+if (!d3) {
+  d3 = window.d3;
+}
+
+module.exports = d3;


### PR DESCRIPTION
For some usage patterns with module loaders, d3 won't be exposed on `window`. By changing the d3 stub to check `require` as well (just as has been done for other dependencies like `dagre`), the issue is resolved.
