### PR TITLE
d3v3 Backward Compatibility

### DIFF
--- a/lib/create-clusters.js
+++ b/lib/create-clusters.js
@@ -38,7 +38,15 @@ function createClusters(selection, g) {
     util.applyStyle(domCluster, node.style);
   });
 
-  util.applyTransition(svgClusters.exit(), g)
+  var exitSelection;
+
+  if (svgClusters.exit) {
+    exitSelection = svgClusters.exit();
+  } else {
+    exitSelection = svgClusters.selectAll(null); // empty selection
+  }
+
+  util.applyTransition(exitSelection, g)
     .style("opacity", 0)
     .remove();
 

--- a/lib/create-edge-labels.js
+++ b/lib/create-edge-labels.js
@@ -30,7 +30,15 @@ function createEdgeLabels(selection, g) {
     if (!_.has(edge, "height")) { edge.height = bbox.height; }
   });
 
-  util.applyTransition(svgEdgeLabels.exit(), g)
+  var exitSelection;
+
+  if (svgEdgeLabels.exit) {
+    exitSelection = svgEdgeLabels.exit();
+  } else {
+    exitSelection = svgEdgeLabels.selectAll(null); // empty selection
+  }
+
+  util.applyTransition(exitSelection, g)
     .style("opacity", 0)
     .remove();
 

--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -78,11 +78,11 @@ function calcPoints(g, e) {
 }
 
 function createLine(edge, points) {
-  var line = d3.line()
+  var line = (d3.line || d3.svg.line)()
     .x(function(d) { return d.x; })
     .y(function(d) { return d.y; });
   
-  line.curve(edge.curve);
+  (line.curve || line.interpolate)(edge.curve);
 
   return line(points);
 }

--- a/lib/create-nodes.js
+++ b/lib/create-nodes.js
@@ -54,7 +54,15 @@ function createNodes(selection, g, shapes) {
     node.height = shapeBBox.height;
   });
 
-  util.applyTransition(svgNodes.exit(), g)
+  var exitSelection;
+
+  if (svgNodes.exit) {
+    exitSelection = svgNodes.exit();
+  } else {
+    exitSelection = svgNodes.selectAll(null); // empty selection
+  }
+
+  util.applyTransition(exitSelection, g)
     .style("opacity", 0)
     .remove();
 


### PR DESCRIPTION
# About
Due to the breaking changes of d3v4, some versions of dagre-d3 does not work with d3v3. However, with some small changes, it can be made compatible with v3, at least for the basic use cases. (I am not sure if these changes solve all compatibility issues; however, it does solve the issues for basic usage).

**Related Issue**: #309 

## Changes
Here are the excerpts from the d3 documentation and changelog which explain the changes:

From the v3 -> v4 [changelog](https://github.com/d3/d3/blob/master/CHANGES.md)

> d3.svg.line ↦ d3.line

> The line.interpolate and area.interpolate methods have been replaced with line.curve and area.curve. 

> In 3.x, the selection.enter and selection.exit methods were undefined until you called selection.data, resulting in a TypeError if you attempted to access them. In 4.0, now they simply return the empty selection if the selection has not been joined to data.

From the v4 [doc](https://github.com/d3/d3-selection/blob/master/README.md#selectAll):

> If no element matches the specified selector for the current element, or if the selector is null, the group at the current index will be empty.