### PR TITLE
Fix render transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.iml
 *.ipr
 yarn.lock
+*.swp

--- a/lib/create-edge-labels.js
+++ b/lib/create-edge-labels.js
@@ -12,17 +12,19 @@ function createEdgeLabels(selection, g) {
     .data(g.edges(), function(e) { return util.edgeToId(e); })
     .classed("update", true);
 
-  svgEdgeLabels.selectAll("*").remove();
+  svgEdgeLabels.exit().remove();
   svgEdgeLabels.enter()
     .append("g")
       .classed("edgeLabel", true)
       .style("opacity", 0);
 
   svgEdgeLabels = selection.selectAll("g.edgeLabel");
-  
+
   svgEdgeLabels.each(function(e) {
+    var root = d3.select(this);
+    root.select('.label').remove();
     var edge = g.edge(e),
-        label = addLabel(d3.select(this), g.edge(e), 0, 0).classed("label", true),
+        label = addLabel(root, g.edge(e), 0, 0).classed("label", true),
         bbox = label.node().getBBox();
 
     if (edge.labelId) { label.attr("id", edge.labelId); }

--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -7,15 +7,14 @@ var _ = require("./lodash"),
 module.exports = createEdgePaths;
 
 function createEdgePaths(selection, g, arrows) {
-  var svgPaths = selection.selectAll("g.edgePath")
+  var previousPaths = selection.selectAll("g.edgePath")
     .data(g.edges(), function(e) { return util.edgeToId(e); })
     .classed("update", true);
 
-  enter(svgPaths, g);
-  exit(svgPaths, g);
+  var newPaths = enter(previousPaths, g);
+  exit(previousPaths, g);
 
-  svgPaths = selection.selectAll("g.edgePath");
-
+  var svgPaths = previousPaths.merge(newPaths);
   util.applyTransition(svgPaths, g)
     .style("opacity", 1);
 
@@ -110,6 +109,7 @@ function enter(svgPaths, g) {
       return createLine(edge, points);
     });
   svgPathsEnter.append("defs");
+  return svgPathsEnter;
 }
 
 function exit(svgPaths, g) {
@@ -117,16 +117,4 @@ function exit(svgPaths, g) {
   util.applyTransition(svgPathExit, g)
     .style("opacity", 0)
     .remove();
-
-  util.applyTransition(svgPathExit.select("path.path"), g)
-    .attr("d", function(e) {
-      var source = g.node(e.v);
-
-      if (source) {
-        var points = _.range(this.getTotalLength()).map(function() { return source; });
-        return createLine({}, points);
-      } else {
-        return d3.select(this).attr("d");
-      }
-    });
 }

--- a/lib/create-nodes.js
+++ b/lib/create-nodes.js
@@ -13,7 +13,7 @@ function createNodes(selection, g, shapes) {
     .data(simpleNodes, function(v) { return v; })
     .classed("update", true);
 
-  svgNodes.selectAll("*").remove();
+  svgNodes.exit().remove();
 
   svgNodes.enter()
     .append("g")
@@ -27,6 +27,8 @@ function createNodes(selection, g, shapes) {
         thisGroup = d3.select(this);
     util.applyClass(thisGroup, node["class"],
       (thisGroup.classed("update") ? "update " : "") + "node");
+
+    thisGroup.select("g.label").remove();
     var labelGroup = thisGroup.append("g").attr("class", "label"),
         labelDom = addLabel(labelGroup, node),
         shape = shapes[node.shape],
@@ -46,7 +48,9 @@ function createNodes(selection, g, shapes) {
       ((node.paddingLeft - node.paddingRight) / 2) + "," +
       ((node.paddingTop - node.paddingBottom) / 2) + ")");
 
-    var shapeSvg = shape(d3.select(this), bbox, node);
+    var root = d3.select(this);
+    root.select(".label-container").remove();
+    var shapeSvg = shape(root, bbox, node).classed("label-container", true);
     util.applyStyle(shapeSvg, node.style);
 
     var shapeBBox = shapeSvg.node().getBBox();

--- a/lib/render.js
+++ b/lib/render.js
@@ -19,8 +19,6 @@ function render() {
   var fn = function(svg, g) {
     preProcessGraph(g);
 
-    svg.selectAll("*").remove();
-
     var outputGroup = createOrSelectGroup(svg, "output"),
         clustersGroup = createOrSelectGroup(outputGroup, "clusters"),
         edgePathsGroup = createOrSelectGroup(outputGroup, "edgePaths"),


### PR DESCRIPTION
Fixes regression discussed in https://github.com/dagrejs/dagre-d3/issues/321. 

The [commit to update to d3.js v4 brought in a change that forces a complete redraw of the graph (due to removing the DOM tree underneath the graph element](https://github.com/dagrejs/dagre-d3/commit/ebbb84f03bd169061f40d7a1df82cb3b51860187#diff-a485abf5b8f49de7f313d7799df3faf4R21). Additionally, a number of other locations were mixing up entering v exiting v updating, so I cleaned that up a bit. Also, fixed an issue in the `exit` function for `edgePaths` that causes the `createLine` call to always fail as it passes in an empty object, which will always lead to an undefined `curve` function being called.