### PR TITLE
Skip call to selection.merge if undefined.

### DIFF
--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -14,7 +14,7 @@ function createEdgePaths(selection, g, arrows) {
   var newPaths = enter(previousPaths, g);
   exit(previousPaths, g);
 
-  var svgPaths = previousPaths.merge(newPaths);
+  var svgPaths = previousPaths.merge !== undefined ? previousPaths.merge(newPaths) : previousPaths;
   util.applyTransition(svgPaths, g)
     .style("opacity", 1);
 


### PR DESCRIPTION
The selection.merge method was added in d3v4. When selection.merge is
undefined, as in d3v3, skip the call and use the existing selection.

This should fix https://github.com/dagrejs/dagre-d3/issues/309#issuecomment-450680411; cc @seelmann.