### PR TITLE
label foreignObject size use g.node's size rather than getBoundingCli…

### DIFF
--- a/lib/label/add-html-label.js
+++ b/lib/label/add-html-label.js
@@ -28,10 +28,9 @@ function addHtmlLabel(root, node) {
   // Fix for firefox
   div.style("white-space", "nowrap");
 
-  var client = div.node().getBoundingClientRect();
   fo
-    .attr("width", client.width)
-    .attr("height", client.height); 
+    .attr("width", node.width)
+    .attr("height", node.height);
 
   return fo;
 }


### PR DESCRIPTION
Dear friends, when I use dagre-d3 to draw a dag graph, it works very well, thanks very much.
When I use  html templates as label of nodes, it still works well. But when I changed the window scale percentage to 80% or other percentage not 100% by command + or command - , it can not work well on chrome and safari, but work well on firefox. 
It seems that the reason is: the getBoundingClientRect api calculated different value on different browser.
When I use the nodes' width and height to replace  getBoundingClientRect, it works well.