### PR TITLE
Consider .rx and .ry properties for rectangular cluster nodes

### DIFF
--- a/lib/create-clusters.js
+++ b/lib/create-clusters.js
@@ -33,7 +33,9 @@ function createClusters(selection, g) {
 
   svgClusters.selectAll("rect").each(function(c) {
     var node = g.node(c);
-    var domCluster = d3.select(this);
+    var domCluster = d3.select(this)
+      .attr("rx", node.rx)
+      .attr("ry", node.ry);
     util.applyStyle(domCluster, node.style);
   });
 


### PR DESCRIPTION
This enables to draw cluster nodes with rounded corners.