### PR TITLE
delete a baseUrl from a marker-end to resolve the disappearance of a path's arrow

### DIFF
--- a/lib/create-edge-paths.js
+++ b/lib/create-edge-paths.js
@@ -39,7 +39,7 @@ function createEdgePaths(selection, g, arrows) {
 
       var domEdge = d3.select(this)
         .attr("marker-end", function() {
-          return "url(" + makeFragmentRef(location.href, edge.arrowheadId) + ")";
+          return "url(#" + edge.arrowheadId + ")";
         })
         .style("fill", "none");
 
@@ -58,11 +58,6 @@ function createEdgePaths(selection, g, arrows) {
     });
 
   return svgPaths;
-}
-
-function makeFragmentRef(url, fragmentId) {
-  var baseUrl = url.split("#")[0];
-  return baseUrl + "#" + fragmentId;
 }
 
 function calcPoints(g, e) {


### PR DESCRIPTION
This PR resolves the disappearance of a path's arrow in some use cases.
An arrowId is just enough to refer an arrow. And in some use cases, a baseUrl created by location.href causes a path's arrow to disappear.

For example, I use this library for drawing paths in a page whose url is changed by a user's action and set event listeners which change paths' color when users click them.
When the url is changed and one of the paths is clicked, it's arrow disappears.
Because it's mark-end reference url is invalid as a result of the difference between the url embedded when the path was rendered and the url changed by the user event.

I think the arrowId without the baseUrl is just enough to refer the arrow.
And to resolve the above matter, I propose deleting the baseUrl from the marker-end reference.
