### PR TITLE
add css class to clusters

### DIFF
--- a/lib/create-clusters.js
+++ b/lib/create-clusters.js
@@ -26,6 +26,8 @@ function createClusters(selection, g) {
   svgClusters.each(function(v) {
     var node = g.node(v);
     var thisGroup = d3.select(this);
+    util.applyClass(thisGroup, node["class"], "cluster");
+
     d3.select(this).append("rect");
     var labelGroup = thisGroup.append("g").attr("class", "label");
     addLabel(labelGroup, node, node.clusterLabelPos);


### PR DESCRIPTION
Solution to add css class from `graph.setNode(`node`, { class: "state-text" })` to clusters in the same way as is done for nodes.
https://github.com/dagrejs/dagre-d3/issues/420